### PR TITLE
Hitting backspace on a list item with nothing in it should delete the…

### DIFF
--- a/Lexical/Core/Nodes/Node.swift
+++ b/Lexical/Core/Nodes/Node.swift
@@ -781,6 +781,10 @@ open class Node: Codable {
   public func isSameNode(_ node: Node) -> Bool {
     return self.getKey() == node.getKey()
   }
+
+  open func isToBeReplacedWithEmptyParagraphOnDeletion() -> Bool {
+    return false
+  }
 }
 
 extension Node: Hashable {

--- a/Lexical/Core/Selection/RangeSelection.swift
+++ b/Lexical/Core/Selection/RangeSelection.swift
@@ -559,6 +559,12 @@ public class RangeSelection: BaseSelection {
       for selectedNode in selectedNodes.dropFirst() {
         let key = selectedNode.key
         if !markedNodeKeysForKeep.contains(key) {
+          if  selectedNode.isToBeReplacedWithEmptyParagraphOnDeletion() && selectedNode.isParentOf(anchorNode) {
+            let paragraphNode = ParagraphNode()
+            try selectedNode.replace(replaceWith: paragraphNode)
+            try paragraphNode.selectStart()
+            continue
+          }
           try selectedNode.remove()
         }
       }

--- a/Plugins/LexicalListPlugin/LexicalListPlugin/ListNode.swift
+++ b/Plugins/LexicalListPlugin/LexicalListPlugin/ListNode.swift
@@ -87,4 +87,8 @@ public class ListNode: ElementNode {
   override public func clone() -> Self {
     Self(listType: listType, start: start, key: key, withPlaceholders: withPlaceholders)
   }
+
+  public override func isToBeReplacedWithEmptyParagraphOnDeletion() -> Bool {
+    return true
+  }
 }


### PR DESCRIPTION
… bullet/number/checkbox and leave you on an empty line (instead of taking you up a line)