### PR TITLE
Different strategy for decorator block nodes

### DIFF
--- a/Lexical/Core/Nodes/DecoratorBlockNode.swift
+++ b/Lexical/Core/Nodes/DecoratorBlockNode.swift
@@ -8,57 +8,10 @@
 import Foundation
 import UIKit
 
-extension NodeType {
-  static let decoratorBlock = NodeType(rawValue: "decorator-block")
-}
+open class DecoratorBlockNode: DecoratorNode {
 
-open class DecoratorBlockNode: ElementNode {
-  override public class func getType() -> NodeType {
-    return .decoratorBlock
+  override public func isInline() -> Bool {
+    return false
   }
 
-  override public required init() {
-    super.init()
-  }
-
-  override public required init(_ key: NodeKey?) {
-    super.init(key)
-  }
-
-  public required init(from decoder: Decoder) throws {
-    try super.init(from: decoder)
-  }
-
-  override public func clone() -> Self {
-    Self(key)
-  }
-
-  open func createDecoratorNode() -> DecoratorNode {
-    fatalError("createDecoratorNode: base method not extended")
-  }
-
-  override open func insertNewAfter(selection: RangeSelection?) throws
-    -> RangeSelection.InsertNewAfterResult
-  {
-    let newElement = createParagraphNode()
-
-    try newElement.setDirection(direction: getDirection())
-    try insertAfter(nodeToInsert: newElement)
-
-    return .init(element: newElement)
-  }
-
-  open func getDecoratorNode() -> DecoratorNode {
-    return getChildren().first! as! DecoratorNode
-  }
-}
-
-public func insertDecoratorBlock(editor: Editor, decoratorBlock: DecoratorBlockNode.Type) throws {
-  try editor.update {
-    if let selection = try getSelection() as? RangeSelection {
-      let block = decoratorBlock.init()
-      try block.append([block.createDecoratorNode()])
-      _ = try selection.insertNodes(nodes: [block], selectStart: false)
-    }
-  }
 }

--- a/Lexical/Core/Nodes/DecoratorNode.swift
+++ b/Lexical/Core/Nodes/DecoratorNode.swift
@@ -93,10 +93,6 @@ open class DecoratorNode: Node {
     fatalError("sizeForDecoratorView: base method not extended")
   }
 
-  open func isTopLevel() -> Bool {
-    return false
-  }
-
   public func isIsolated() -> Bool {
     return false
   }

--- a/Lexical/Core/Nodes/DecoratorNode.swift
+++ b/Lexical/Core/Nodes/DecoratorNode.swift
@@ -108,6 +108,41 @@ open class DecoratorNode: Node {
     return ""
   }
 
+  // TODO: I tried copying this from element node but it doesn't look like it's getting called
+  @discardableResult
+  public func select(anchorOffset: Int?, focusOffset: Int?) throws -> RangeSelection {
+    try errorOnReadOnly()
+
+    let selection = try getSelection()
+    let childrenCount = 0
+    var updatedAnchorOffset = childrenCount
+    var updatedFocusOffset = childrenCount
+
+    if let anchorOffset {
+      updatedAnchorOffset = anchorOffset
+    }
+
+    if let focusOffset {
+      updatedFocusOffset = focusOffset
+    }
+
+    guard let selection = selection as? RangeSelection else {
+      return try makeRangeSelection(
+        anchorKey: key,
+        anchorOffset: updatedAnchorOffset,
+        focusKey: key,
+        focusOffset: updatedFocusOffset,
+        anchorType: .element,
+        focusType: .element)
+    }
+
+    selection.anchor.updatePoint(key: key, offset: updatedAnchorOffset, type: .element)
+    selection.focus.updatePoint(key: key, offset: updatedFocusOffset, type: .element)
+    selection.dirty = true
+
+    return selection
+  }
+
   override public func getAttributedStringAttributes(theme: Theme) -> [NSAttributedString.Key: Any] {
     let textAttachment = TextAttachment()
 

--- a/Lexical/Core/Nodes/DecoratorNode.swift
+++ b/Lexical/Core/Nodes/DecoratorNode.swift
@@ -111,7 +111,7 @@ open class DecoratorNode: Node {
     }
 
     let parent = try getParentOrThrow()
-    let selectionIndex = indexWithinParent - 1
+    let selectionIndex = max(0, indexWithinParent - 1)
     return try parent.select(anchorOffset: selectionIndex, focusOffset: selectionIndex)
   }
 

--- a/Lexical/Core/Nodes/DecoratorNode.swift
+++ b/Lexical/Core/Nodes/DecoratorNode.swift
@@ -112,9 +112,12 @@ open class DecoratorNode: Node {
 
     let parent = try getParentOrThrow()
     let selectionIndex = max(0, indexWithinParent - 1)
+    if selectionIndex == 0 {
+      return try selectPrevious(anchorOffset: nil, focusOffset: nil)
+    }
+
     return try parent.select(anchorOffset: selectionIndex, focusOffset: selectionIndex)
   }
-
 
   @discardableResult
   public func selectEnd() throws -> RangeSelection {

--- a/Lexical/Core/Nodes/DecoratorNode.swift
+++ b/Lexical/Core/Nodes/DecoratorNode.swift
@@ -137,4 +137,17 @@ open class DecoratorNode: Node {
 
     return [.attachment: textAttachment]
   }
+
+  @discardableResult
+  open func collapseAtStart(selection: RangeSelection) throws -> Bool {
+    if !isInline() {
+      let paragraph = createParagraphNode()
+      try replace(replaceWith: paragraph)
+      try paragraph.selectStart()
+      return true
+    }
+
+    return false
+  }
+
 }

--- a/Lexical/Core/Nodes/ElementNode.swift
+++ b/Lexical/Core/Nodes/ElementNode.swift
@@ -260,7 +260,7 @@ open class ElementNode: Node {
     return true
   }
 
-  open func isInline() -> Bool {
+  override open func isInline() -> Bool {
     return false
   }
 
@@ -304,8 +304,7 @@ open class ElementNode: Node {
       return ""
     }
 
-    guard prevSibling is ElementNode else {
-      // prev is not an element node. Treat it as inline (TODO: inline handling in decorators)
+    guard !prevSibling.isInline() else {
       // Since prev is inline but not an element node, and we're not inline, return a newline
       return "\n"
     }
@@ -321,8 +320,8 @@ open class ElementNode: Node {
       // we have no next sibling, return "" no matter whether we're inline or not
       return ""
     } else if isInline() {
-      if let nextSiblingAsElement = nextSibling as? ElementNode, !nextSiblingAsElement.isInline() {
-        // we're inline but the next sibling is an element but is not inline
+      if let nextSibling, !nextSibling.isInline() {
+        // we're inline but the next sibling is not inline
         return "\n"
       } else {
         // we're inline, next sibling is either a text node or inline

--- a/Lexical/Core/Nodes/ElementNode.swift
+++ b/Lexical/Core/Nodes/ElementNode.swift
@@ -304,7 +304,7 @@ open class ElementNode: Node {
       return ""
     }
 
-    guard !prevSibling.isInline() else {
+    guard prevSibling is ElementNode else {
       // Since prev is inline but not an element node, and we're not inline, return a newline
       return "\n"
     }

--- a/Lexical/Core/Nodes/Node.swift
+++ b/Lexical/Core/Nodes/Node.swift
@@ -755,6 +755,9 @@ open class Node: Codable {
       return try previousSibling.select(anchorOffset: nil, focusOffset: nil)
     } else if let previousSibling = previousSibling as? TextNode {
       return try previousSibling.select(anchorOffset: anchorOffset, focusOffset: focusOffset)
+    } else if let previousSibling = previousSibling as? DecoratorNode {
+      print("select previous: \(previousSibling)")
+      return try previousSibling.select(anchorOffset: anchorOffset, focusOffset: focusOffset)
     } else {
       var index = previousSibling?.getIndexWithinParent()
       index = index ?? 0 + 1
@@ -775,6 +778,9 @@ open class Node: Codable {
     if let nextSibling = nextSibling as? ElementNode {
       return try nextSibling.select(anchorOffset: 0, focusOffset: 0)
     } else if let nextSibling = nextSibling as? TextNode {
+      return try nextSibling.select(anchorOffset: anchorOffset, focusOffset: focusOffset)
+    } else if let nextSibling = nextSibling as? DecoratorNode {
+      print("select next: \(nextSibling)")
       return try nextSibling.select(anchorOffset: anchorOffset, focusOffset: focusOffset)
     } else {
       let index = nextSibling?.getIndexWithinParent()

--- a/Lexical/Core/Nodes/Node.swift
+++ b/Lexical/Core/Nodes/Node.swift
@@ -74,6 +74,10 @@ open class Node: Codable {
     }
   }
 
+  open func isInline() -> Bool {
+    return true
+  }
+
   /// Provides the **preamble** part of the node's content. Typically the preamble is used for control characters to represent embedded objects (see ``DecoratorNode``).
   ///
   /// In Lexical iOS, a node's content is split into four parts: preamble, children, text, postamble. ``ElementNode`` subclasses can implement preamble/postamble, and TextNode subclasses can implement the text part.

--- a/Lexical/Core/Nodes/Node.swift
+++ b/Lexical/Core/Nodes/Node.swift
@@ -756,8 +756,7 @@ open class Node: Codable {
     } else if let previousSibling = previousSibling as? TextNode {
       return try previousSibling.select(anchorOffset: anchorOffset, focusOffset: focusOffset)
     } else if let previousSibling = previousSibling as? DecoratorNode {
-      print("select previous: \(previousSibling)")
-      return try previousSibling.select(anchorOffset: anchorOffset, focusOffset: focusOffset)
+      return try previousSibling.selectEnd()
     } else {
       var index = previousSibling?.getIndexWithinParent()
       index = index ?? 0 + 1
@@ -780,8 +779,7 @@ open class Node: Codable {
     } else if let nextSibling = nextSibling as? TextNode {
       return try nextSibling.select(anchorOffset: anchorOffset, focusOffset: focusOffset)
     } else if let nextSibling = nextSibling as? DecoratorNode {
-      print("select next: \(nextSibling)")
-      return try nextSibling.select(anchorOffset: anchorOffset, focusOffset: focusOffset)
+      return try nextSibling.selectStart()
     } else {
       let index = nextSibling?.getIndexWithinParent()
       return try parent.select(anchorOffset: index, focusOffset: index)

--- a/Lexical/Core/Reconciler.swift
+++ b/Lexical/Core/Reconciler.swift
@@ -320,9 +320,7 @@ internal enum Reconciler {
     // for any decorator node siblings after the next node we need to decorate it to handle any repositioning
     var nextSibling = nextNode.getNextSibling()
     while nextSibling != nil {
-      if let nextSibling = nextSibling as? DecoratorBlockNode {
-        reconcilerState.decoratorsToDecorate.append(nextSibling.getDecoratorNode().key)
-      } else if let nextSibling = nextSibling as? DecoratorNode {
+      if let nextSibling = nextSibling as? DecoratorNode {
         reconcilerState.decoratorsToDecorate.append(nextSibling.key)
       }
       nextSibling = nextSibling?.getNextSibling()

--- a/Lexical/Core/Selection/RangeSelection.swift
+++ b/Lexical/Core/Selection/RangeSelection.swift
@@ -265,11 +265,6 @@ public class RangeSelection: BaseSelection {
     let style = style
     let anchorNode = try anchor.getNode()
 
-    if anchorNode is DecoratorBlockNode {
-      // we're not allowing inserting text into decorator block node
-      return
-    }
-
     if isBefore && anchor.type == .element {
       try transferStartingElementPointToTextPoint(start: anchor, end: focus, format: format, style: style)
     } else if !isBefore && focus.type == .element {
@@ -590,11 +585,6 @@ public class RangeSelection: BaseSelection {
     let anchorOffset = anchor.offset
     let anchorNode = try anchor.getNode()
     var target = anchorNode
-
-    // TODO: delete DecoratorBlockNode
-    if anchorNode is DecoratorBlockNode {
-      return false // there is no insertion into DecoratorBlockNode
-    }
 
     if anchor.type == .element {
       if let element = try anchor.getNode() as? ElementNode {
@@ -1018,20 +1008,6 @@ public class RangeSelection: BaseSelection {
             return
           }
         }
-      }
-
-      // Handle the deletion around decorator block nodes.
-      if let decoratorBlockNode = anchorNode as? DecoratorBlockNode {
-        // NK TODO this should take into account direction, for right to left text I guess
-        let previousSibling = decoratorBlockNode.getPreviousSibling()
-        if anchor.offset == 1 {
-          try decoratorBlockNode.remove()
-        }
-        if  let previousSiblingAsParagraphNode = previousSibling as? ParagraphNode,
-            let lastTextNodeInPreviousSibling = previousSiblingAsParagraphNode.getLastChild() as? TextNode{
-          try? _ = lastTextNodeInPreviousSibling.select(anchorOffset: nil, focusOffset: nil)
-        }
-        return
       }
 
       // Handle the deletion around decorators.

--- a/Lexical/Core/Selection/RangeSelection.swift
+++ b/Lexical/Core/Selection/RangeSelection.swift
@@ -795,8 +795,11 @@ public class RangeSelection: BaseSelection {
     var updatedTarget = target
 
     if isDecoratorBlockNode(target) {
-      updatedTarget = try target.insertAfter(nodeToInsert: node)
-      return updatedTarget
+      return try target.insertAfter(nodeToInsert: node)
+    }
+
+    if !isElementNode(node: node) {
+      return try target.insertAfter(nodeToInsert: node)
     }
 
     guard let elementTarget = target as? ElementNode else {

--- a/Lexical/Core/Selection/RangeSelection.swift
+++ b/Lexical/Core/Selection/RangeSelection.swift
@@ -1046,7 +1046,6 @@ public class RangeSelection: BaseSelection {
         return
       } else if isRootNode(node: anchorNode),
                 let adjacentNode = adjacentNode as? ElementNode,
-                adjacentNode.isEmpty(),
                 let adjacentNodeSibling = adjacentNode.getNextSibling() as? DecoratorNode,
                 !adjacentNodeSibling.isInline() {
         // A decorator block node's selection is represented as an index within
@@ -1055,8 +1054,14 @@ public class RangeSelection: BaseSelection {
         // the adjacent node is the node preceding the decorator block node
         // (adjacentNode here). We check the adjacent node next sibling to see
         // if it's a decorator node to properly handle this case.
-        try adjacentNode.remove()
-        try adjacentNodeSibling.selectStart()
+
+        if adjacentNode.isEmpty() {
+          try adjacentNode.remove()
+          try adjacentNodeSibling.selectStart()
+        } else {
+          try adjacentNode.selectEnd()
+        }
+
         return
       } else if !isBackwards, let possibleNode = adjacentNode as? ElementNode, let anchorNode = anchorNode as? ElementNode, anchorNode.isEmpty() {
         try anchorNode.remove()

--- a/Lexical/Core/Selection/RangeSelection.swift
+++ b/Lexical/Core/Selection/RangeSelection.swift
@@ -463,7 +463,7 @@ public class RangeSelection: BaseSelection {
         endPoint.type == .element && (lastNode?.getIndexWithinParent() ?? 0 < endOffset)
       let shouldModifyDecoratorNode = !isDecoratorBlockNode(lastNode)
 
-      if (shouldModifyTextNode || shouldModifyElementNode) && !shouldModifyDecoratorNode {
+      if (shouldModifyTextNode || shouldModifyElementNode) && shouldModifyDecoratorNode {
         if let lastNodeAsTextNode = lastNode as? TextNode,
            !lastNodeAsTextNode.isToken(),
            endOffset != lastNodeAsTextNode.getTextContentSize() {

--- a/Lexical/Core/Selection/SelectionUtils.swift
+++ b/Lexical/Core/Selection/SelectionUtils.swift
@@ -549,7 +549,7 @@ public func setBlocksType(
 
 private func isBlock(_ node: Node) -> Bool {
   guard let node = node as? ElementNode, !isRootNode(node: node) else {
-    return false
+    return !node.isInline()
   }
 
   let firstChild = node.getFirstChild()

--- a/Lexical/Core/Utils.swift
+++ b/Lexical/Core/Utils.swift
@@ -202,6 +202,13 @@ public func isDecoratorNode(_ node: Node?) -> Bool {
   node is DecoratorNode
 }
 
+public func isDecoratorBlockNode(_ node: Node?) -> Bool {
+  if let decoratorNode = node as? DecoratorNode {
+    return !decoratorNode.isInline()
+  }
+  return false
+}
+
 // TODO: - update function when we add LineBreakNode and DecoratorNode
 public func isLeafNode(_ node: Node?) -> Bool {
   node is TextNode || node is LineBreakNode

--- a/Lexical/TextKit/RangeCache.swift
+++ b/Lexical/TextKit/RangeCache.swift
@@ -77,11 +77,6 @@ private func evaluateNode(_ nodeKey: NodeKey, stringLocation: Int, searchDirecti
     }
   }
 
-  if isDecoratorBlockNode(node) {
-    let boundary: RangeCacheSearchResultType = (searchDirection == .forward) ? .startBoundary : .endBoundary
-    return RangeCacheSearchResult(nodeKey: nodeKey, type: boundary, offset: nil)
-  }
-
   if let node = node as? ElementNode {
     let childrenArray = (searchDirection == .forward) ? node.getChildrenKeys() : node.getChildrenKeys().reversed()
 
@@ -134,7 +129,6 @@ private func evaluateNode(_ nodeKey: NodeKey, stringLocation: Int, searchDirecti
 
   let preambleEnd = rangeCacheItem.location + rangeCacheItem.preambleLength
   if stringLocation == preambleEnd {
-    print("returning start boundary: \(nodeKey) -- \(stringLocation) -- \(preambleEnd)")
     return RangeCacheSearchResult(nodeKey: nodeKey, type: .startBoundary, offset: nil)
   }
 

--- a/Lexical/TextKit/RangeCache.swift
+++ b/Lexical/TextKit/RangeCache.swift
@@ -77,6 +77,11 @@ private func evaluateNode(_ nodeKey: NodeKey, stringLocation: Int, searchDirecti
     }
   }
 
+  if isDecoratorBlockNode(node) {
+    let boundary: RangeCacheSearchResultType = (searchDirection == .forward) ? .startBoundary : .endBoundary
+    return RangeCacheSearchResult(nodeKey: nodeKey, type: boundary, offset: nil)
+  }
+
   if let node = node as? ElementNode {
     let childrenArray = (searchDirection == .forward) ? node.getChildrenKeys() : node.getChildrenKeys().reversed()
 
@@ -97,6 +102,7 @@ private func evaluateNode(_ nodeKey: NodeKey, stringLocation: Int, searchDirecti
         possibleBoundaryElementResult = RangeCacheSearchResult(nodeKey: nodeKey, type: .element, offset: childIndex + 1)
       }
     }
+
     if let possibleBoundaryElementResult {
       // We do this 'possible result' check so that we prioritise text results where we can.
       return possibleBoundaryElementResult
@@ -124,6 +130,12 @@ private func evaluateNode(_ nodeKey: NodeKey, stringLocation: Int, searchDirecti
 
   if stringLocation == rangeCacheItem.entireRange().upperBound {
     return RangeCacheSearchResult(nodeKey: nodeKey, type: .endBoundary, offset: nil)
+  }
+
+  let preambleEnd = rangeCacheItem.location + rangeCacheItem.preambleLength
+  if stringLocation == preambleEnd {
+    print("returning start boundary: \(nodeKey) -- \(stringLocation) -- \(preambleEnd)")
+    return RangeCacheSearchResult(nodeKey: nodeKey, type: .startBoundary, offset: nil)
   }
 
   return RangeCacheSearchResult(nodeKey: nodeKey, type: .illegal, offset: nil)

--- a/Playground/LexicalPlayground/ToolbarPlugin.swift
+++ b/Playground/LexicalPlayground/ToolbarPlugin.swift
@@ -45,6 +45,10 @@ class SampleDecoratorNode: DecoratorNode {
     return CGSizeMake(textViewWidth, 50)
   }
 
+  override open func isInline() -> Bool {
+    return false
+  }
+
 }
 
 public class ToolbarPlugin: Plugin {
@@ -391,7 +395,13 @@ public class ToolbarPlugin: Plugin {
   }
   @objc private func sampleDecoratorBlock() {
     guard let editor else { return }
-    try? insertDecoratorBlock(editor: editor, decoratorBlock: SampleDecoratorBlockNode.self)
+    try? editor.update {
+      let sampleDecoratorNode = SampleDecoratorNode()
+      if let selection = try getSelection() {
+        _ = try selection.insertNodes(nodes: [sampleDecoratorNode], selectStart: false)
+      }
+    }
+//    try? insertDecoratorBlock(editor: editor, decoratorBlock: SampleDecoratorBlockNode.self)
   }
   @objc private func increaseIndent() {
     editor?.dispatchCommand(type: .indentContent, payload: nil)

--- a/Playground/LexicalPlayground/ToolbarPlugin.swift
+++ b/Playground/LexicalPlayground/ToolbarPlugin.swift
@@ -14,17 +14,11 @@ import LexicalListPlugin
 import SelectableDecoratorNode
 import UIKit
 
-class SampleDecoratorBlockNode: DecoratorBlockNode {
-  override func createDecoratorNode() -> DecoratorNode {
-    return SampleDecoratorNode()
-  }
-}
-
 extension NodeType {
   static let sampleDecorator = NodeType(rawValue: "sampleDecorator")
 }
 
-class SampleDecoratorNode: DecoratorNode {
+class SampleDecoratorNode: DecoratorBlockNode {
 
   override public class func getType() -> NodeType {
     return .sampleDecorator
@@ -43,10 +37,6 @@ class SampleDecoratorNode: DecoratorNode {
     textViewWidth: CGFloat, attributes: [NSAttributedString.Key: Any]
   ) -> CGSize {
     return CGSizeMake(textViewWidth, 50)
-  }
-
-  override open func isInline() -> Bool {
-    return false
   }
 
 }


### PR DESCRIPTION
This mostly does what we want but the selection logic is weird. If you move the cursor before the decorator block node, the cursor is at the "root" level, which then makes deletions and insertions behave weirdly.

https://github.com/user-attachments/assets/a47403f8-db1a-451d-ae73-c9542f9d3b50

If you look at this video, when the cursor is before the decorator node, you can see in the debug footer that the selection is "root" with the offset of 1. So when you hit backspace, it deletes the whole next paragraph node instead of a single character.

I think we could potentially just handle that case, but then there are other cases where it will throw an invariant violation around losing the cursor position.

If we can figure out how the selection should work for this I can fix the node insertion issues (there is an issue where if you insert the decorator block node within a paragraph with text, it treats it as an inline element). I had a fix for this but lost it when trying to clean up some debug logging.


