### PR TITLE
allow for insert new after result to abort

### DIFF
--- a/Lexical/Core/Selection/RangeSelection.swift
+++ b/Lexical/Core/Selection/RangeSelection.swift
@@ -14,11 +14,13 @@ public class RangeSelection: BaseSelection {
     public let element: Node?
     public let skipLineBreak: Bool
     public let skipSelectStart: Bool
+    public let abort: Bool
 
-    public init(element: ElementNode? = nil, skipLineBreak: Bool = false, skipSelectStart: Bool = false) {
+    public init(element: ElementNode? = nil, skipLineBreak: Bool = false, skipSelectStart: Bool = false, abort: Bool = false) {
       self.element = element
       self.skipLineBreak = skipLineBreak
       self.skipSelectStart = skipSelectStart
+      self.abort = abort
     }
   }
 
@@ -900,6 +902,7 @@ public class RangeSelection: BaseSelection {
     if anchorOffset == 0 && nodesToMoveLength > 0 && currentElement.isInline() {
       let parent = try currentElement.getParentOrThrow()
       let result = try parent.insertNewAfter(selection: self)
+      if result.abort { return }
       let newElement = result.element
       if let newElement = newElement as? ElementNode {
         let children = parent.getChildren()
@@ -912,6 +915,7 @@ public class RangeSelection: BaseSelection {
 
     let currentParent = try currentElement.getParentOrThrow()
     let result = try currentElement.insertNewAfter(selection: self)
+    if result.abort { return }
     let newElement = result.element
     if newElement == nil {
       if !result.skipLineBreak {


### PR DESCRIPTION
Hey Michael,

we need to be able to abort the `insertNewAfter` flow since there are cases we don't want to insert new line on enter if we want lists to behave as in Slack Canvas

My PR I'm creating in Pine depends on this