### PR TITLE
Pin 378 fixed caret size

### DIFF
--- a/Lexical/TextView/TextView.swift
+++ b/Lexical/TextView/TextView.swift
@@ -578,25 +578,6 @@ private class CaretAndSelectionRectsAdjuster {
     return modifiedRects
   }
 
-  static func isCaretOnLastLine(for position: UITextPosition, in textView: UITextView) -> Bool {
-    let caretOffset = textView.offset(from: textView.beginningOfDocument, to: position)
-
-    // Get the paragraph range containing the caret
-    let nsText = textView.textStorage.string as NSString
-    let paragraphRange = nsText.paragraphRange(for: NSRange(location: caretOffset, length: 0))
-
-    // Check line fragment of the caret
-    let glyphIndex = textView.layoutManager.glyphIndexForCharacter(at: caretOffset)
-    let lineFragmentRect = textView.layoutManager.lineFragmentRect(forGlyphAt: glyphIndex, effectiveRange: nil)
-
-    // Determine the last line of the paragraph
-    let paragraphEndGlyphIndex = textView.layoutManager.glyphIndexForCharacter(at: paragraphRange.upperBound - 1)
-    let lastLineFragmentRect = textView.layoutManager.lineFragmentRect(forGlyphAt: paragraphEndGlyphIndex, effectiveRange: nil)
-
-    // Compare the current caret's line to the last line of the paragraph
-    return lineFragmentRect == lastLineFragmentRect
-  }
-
 }
 
 // Custom UITextSelectionRect subclass for modified rects

--- a/Lexical/TextView/TextView.swift
+++ b/Lexical/TextView/TextView.swift
@@ -542,14 +542,18 @@ private class CaretAndSelectionRectsAdjuster {
 
   static func adjustCaretRect(_ originalRect: CGRect, for position: UITextPosition, in textView: UITextView) -> CGRect {
     var result = originalRect
-    if isCaretOnLastLine(for: position, in: textView) {
-      // Find the caret position as an index in the text
-      let offset = textView.offset(from: textView.beginningOfDocument, to: position)
-      // Retrieve attributes at the caret position
-      let attributes = textView.textStorage.attributes(at: offset, effectiveRange: nil)
-      if let paragraphStyle = attributes[.paragraphStyle] as? NSParagraphStyle {
-        result.size.height = result.size.height - paragraphStyle.paragraphSpacing
-      }
+    // Find the caret position as an index in the text
+    let offset = textView.offset(from: textView.beginningOfDocument, to: position)
+    // Retrieve attributes at the caret position
+    let attributes = textView.textStorage.attributes(at: offset, effectiveRange: nil)
+    if let paragraphStyle = attributes[.paragraphStyle] as? NSParagraphStyle,
+       paragraphStyle.paragraphSpacing > 0 {
+      // there is paragraph spacing, in that case we opt for a fixed size caret
+      guard let font = textView.font else { return result }
+
+      // "descender" is expressed as a negative value,
+      // so to add its height you must subtract its value
+      result.size.height = font.pointSize - font.descender
     }
 
     return result


### PR DESCRIPTION
When there is another element node inside a heading caret size goes berserk, `isCaretOnLastLine` becomes totally unreliable so I opted to just have a reasonable fixed size care to avoid such glitches